### PR TITLE
Remove server name nginx config

### DIFF
--- a/dmadminweb/microservice/nginx.conf
+++ b/dmadminweb/microservice/nginx.conf
@@ -114,7 +114,6 @@ upstream ao-ms-dep-pkg-get-backend {
 
 server {
         listen       80;
-        server_name  dev.ortelius.io;
         rewrite ^(.*) https://$server_name$1 permanent;
    }
 			
@@ -122,7 +121,6 @@ server {
     	listen 443 ssl http2;
     	listen [::]:443 ssl http2;
 
-        server_name dev.ortelius.io;
         root /var/www;
 		index index.html;
 		client_max_body_size 100M;																


### PR DESCRIPTION
Remove server_name option to use an empty name